### PR TITLE
Add Aviate integration to `/api/user/:user`

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,11 +63,16 @@ app.get('/api/user/:name', cors(), async (req, res) => {
     let noReplace = req.query.noReplace
     let user = await getUserData(req.params.name.replace('*', ''))
     let aviateData = await fetch(`https://aviateapp.eu.org/api/${user.name}${noReplace ? '?code=true' : ''}`)
+    let aviateStatus;
     
     if (aviateData.ok) {
         let json = await aviateData.json()
         
-        user.status = json.status
+        aviateStatus = json.status
+    }
+    
+    if (aviateStatus) {
+        user.status = aviateStatus
     } else if (!noReplace && user) {
         let allUsers = await users.find()
         

--- a/index.js
+++ b/index.js
@@ -62,9 +62,15 @@ app.get('/api/users', cors(corsOptions), async (req, res) => {
 app.get('/api/user/:name', cors(), async (req, res) => {
     let noReplace = req.query.noReplace
     let user = await getUserData(req.params.name.replace('*', ''))
-    let allUsers = await users.find()
-
-    if (!noReplace && user) {
+    let aviateData = await fetch(`https://aviateapp.eu.org/api/${user.name}${noReplace ? '?code=true' : ''}`);
+    
+    if (aviateData.ok) {
+        let json = await aviateData.json();
+        
+        user.status = json.status;
+    } else if (!noReplace && user) {
+        let allUsers = await users.find()
+        
         user.status = user.status.replace(/(?<!\\){joke}/g, jokes[Math.floor(Math.random() * jokes.length)])
         user.status = user.status.replace(/\\({joke})/g, "$1")
 

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ app.get('/api/user/:name', cors(), async (req, res) => {
     let noReplace = req.query.noReplace
     let user = await getUserData(req.params.name.replace('*', ''))
     let aviateData = await fetch(`https://aviateapp.eu.org/api/${user.name}${noReplace ? '?code=true' : ''}`)
-    let aviateStatus;
+    let aviateStatus
     
     if (aviateData.ok) {
         let json = await aviateData.json()

--- a/index.js
+++ b/index.js
@@ -62,12 +62,12 @@ app.get('/api/users', cors(corsOptions), async (req, res) => {
 app.get('/api/user/:name', cors(), async (req, res) => {
     let noReplace = req.query.noReplace
     let user = await getUserData(req.params.name.replace('*', ''))
-    let aviateData = await fetch(`https://aviateapp.eu.org/api/${user.name}${noReplace ? '?code=true' : ''}`);
+    let aviateData = await fetch(`https://aviateapp.eu.org/api/${user.name}${noReplace ? '?code=true' : ''}`)
     
     if (aviateData.ok) {
-        let json = await aviateData.json();
+        let json = await aviateData.json()
         
-        user.status = json.status;
+        user.status = json.status
     } else if (!noReplace && user) {
         let allUsers = await users.find()
         


### PR DESCRIPTION
For every request to `/api/user/:user`, first check if the user has an Aviate status. If they do, use their Aviate status, otherwise use their ocular status. 

I also moved `let allUsers = await users.find()` to inside of the `else if` statement to speed up the code a bit.